### PR TITLE
Fix year symbol in date formatting.

### DIFF
--- a/src/main/kotlin/me/alexflipnote/kawaiibot/entities/Responses.kt
+++ b/src/main/kotlin/me/alexflipnote/kawaiibot/entities/Responses.kt
@@ -5,7 +5,7 @@ import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
 object Responses {
-    private val dateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM YYYY, kk:mm")
+    private val dateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM uuuu, kk:mm")
 
     fun responsible(author: User, reason: String = ""): String {
         return "[ ${author.name}#${author.discriminator} ] ${if (reason.isEmpty()) "No reason given." else reason}"


### PR DESCRIPTION
YYYY is the symbol for "week-based-year", "uuuu" is the correct symbol for "year".
Using YYYY causes issues like this one in +joinedat where it says people joined in the future: https://i.imgur.com/mCRjLs1.png